### PR TITLE
Jj/feature/update and delete

### DIFF
--- a/get_data/README.md
+++ b/get_data/README.md
@@ -19,7 +19,22 @@ with 5 directions and another label with 3 directions. Hence the number of eleme
 of element in ES.
 - Each picture in S3 has a unique id called `img_id` which is the timestamp of the picture
 (eg: 20201231T15-45-55-123456)
-- Labels stored in ES contains a "img_id" field with the id of the picture it refers to.
+- Labels stored in ES contains a "img_id" field with the id of the picture it refers to. A label in Elasticsearch is a 
+json like document that look to something like this:
+```
+{
+  "img_id": "20200119T14-30-55-123456",
+  "event": "iron car",
+  "car_setting": {...},
+  "label" : {
+    "label_speed": 1,
+    "label_direction": 2,
+    ...
+  },
+  "label_fingerprint": "e170fca7848a59a815d2288802cc2832",
+  ...
+}
+```
 - Each labels stored in ES has a unique id called `label_fingerprint`. This id is a hash of the following fields: 
 `["img_id", "created_by", "label_direction", "label_speed", "nb_dir", "nb_speed"]`. This `label_fingerprint` 
 shall be unique among the labels in the DB. If two labels have exactly the same value on those 6 fields, 
@@ -35,13 +50,13 @@ they will have the same hash, and hence, they will be considered duplicate and i
     ...
   }
   ```
-  The key is the `img_id` and the value is the label associated to this picture. If the search returns several labels 
-  for a same `img_id`, only one label will be kept and a message is printed to warn the user.
+  The key is the `img_id` and the value is the label, as stored in ES, associated to this picture. If the search returns
+   several labels for a same `img_id`, only one label will be kept and a message is printed to warn the user.
 - This "labels.json" file is 'disposable'. Every time one wants to train a model, he shall request the ES database to 
-get this file listing all the picture required for the training he wished to run.
+get this file listing all the pictures required for the training he wished to run.
 
 
-## 2. How to record picture and create label
+## 2. How to record picture and create labels
 
 The script `run_manual.py` is used to run the car in manual mode (control with xbox pad). Picture will be recorded
 during the run and for each recorded picture, a label is automatically created.  
@@ -61,11 +76,12 @@ Usage:
 2. Run the car with `run_manual.py` to collect data. Run `run_manual.py -h` for the usage.   
   
    If the output folder you provide to the script does not exist or has no session_template.json file,
-   it will be created automatically.
+   it will be created automatically. The session template contains information about the session (event name, track 
+   type, ...etc) that are common to all the pictures of this session.
      
-   This script will record the pictures and create the label for each pictures. All the labels will be saved in a single 
-file. Each labels will contains the session_template.json data and the hardware_conf data plus information specific 
-to each pictures.  
+   The script will record the pictures and create the label for each pictures. All the labels will be saved in a single 
+file. Each labels will contains the session_template.json data and the hardware_conf.json data, plus information 
+specific to each pictures.  
 Example of info specific to each picture
  (the following might not be up to date. See **Label Template** chapter for the actual template):
    ```
@@ -120,6 +136,14 @@ export ES_USER_PWD="your_es_password"
 ## 4. How to re lablize pictures manually
 
 TO DO
+  
+Once you have re-labelized the pictures and pointed to the picture to be delete, a new `labels.json` file will be 
+generated from the GUI. This file contains the new labels and the label the shall be deleted (a field "to_delete" is 
+added in the label). All you need to do to upload new label and delete label + picture selected is to run the 
+`upload_to_db.py` scripts.  
+
+The script will upload the new label and for each label with the field "to_delete", delete the associated picture from 
+S3 and the label from ES. Note: the picture will only be deleted if no other labels in the database points to it.
 
 ## 5. How to search and download pictures from the database
 

--- a/get_data/src/s3_utils.py
+++ b/get_data/src/s3_utils.py
@@ -38,7 +38,7 @@ def get_s3_resource():
     return s3
 
 
-def file_exist_in_bucket(s3, bucket, key):
+def object_exist_in_bucket(s3, bucket, key):
     """check if key already exists in bucket. Return True if exists, False otherwise."""
     try:
         s3.Object(bucket, key).load()
@@ -69,7 +69,7 @@ def upload_to_s3_from_label(d_label, s3_bucket_name, prefix="", overwrite=False)
     for pic_id, label in tqdm(d_label.items()):
         picture = Path(label["location"]) / label["file_name"]
         key = prefix + pic_id
-        if not overwrite and file_exist_in_bucket(s3, s3_bucket_name, key):
+        if not overwrite and object_exist_in_bucket(s3, s3_bucket_name, key):
             log += f'  --> Can\'t upload file "{picture}" because key "{key}" already exists in bucket "{s3_bucket_name}"\n'
             already_exist_pic.append(pic_id)
         else:
@@ -101,6 +101,12 @@ def get_s3_formatted_bucket_path(bucket_name, key_prefix, file_name=None):
 
     >>> get_s3_formatted_bucket_path("my-bucket", "", "key_prefix/file.jpg")
     ("my-bucket/key_prefix/file.jpg", "my-bucket", "key_prefix/file.jpg")
+
+    >>> get_s3_formatted_bucket_path("my-bucket/key/prefix", "")
+    ("my-bucket/key/prefix/", "my-bucket", "key/prefix/")
+
+    >>> get_s3_formatted_bucket_path("my-bucket/key/prefix", "", "/file")
+    ("my-bucket/key/prefix/file", "my-bucket", "key/prefix/file")
     """
     if file_name is None:
         raw_dir = bucket_name + "/" + key_prefix
@@ -108,12 +114,12 @@ def get_s3_formatted_bucket_path(bucket_name, key_prefix, file_name=None):
         raw_dir = bucket_name + "/" + key_prefix + "/" + file_name
     dir_list_clean = [elm for elm in raw_dir.split("/") if bool(elm)]
     clean_full_path = "/".join(dir_list_clean)
-    clean_key_prefix = "/".join(dir_list_clean[1:]) if len(dir_list_clean) > 1 else ""
+    clean_key = "/".join(dir_list_clean[1:]) if len(dir_list_clean) > 1 else ""
     if file_name is None:
         clean_full_path += "/"
-        clean_key_prefix += "/" if clean_key_prefix != "" else ""
+        clean_key += "/" if clean_key != "" else ""
     clean_bucket_name = dir_list_clean[0]
-    return clean_full_path, clean_bucket_name, clean_key_prefix
+    return clean_full_path, clean_bucket_name, clean_key
 
 
 def split_s3_path(bucket_key):
@@ -125,17 +131,18 @@ def split_s3_path(bucket_key):
     return bucket, key_prefix, file_name
 
 
-def delete_object_s3(bucket, key_prefix, l_object_key, s3_resource=None):
-    """Delete all object listed in l_object_key and with prefix key_prefix"""
-    full_path, bucket, key_prefix = get_s3_formatted_bucket_path(bucket, key_prefix)
+def delete_object_s3(bucket, l_object_key, s3_resource=None):
+    """Delete all object in bucket with key listed in l_object_key"""
     if s3_resource is None:
         s3_resource = get_s3_resource()
+    _, bucket, _ = get_s3_formatted_bucket_path(bucket, "")
     s3_bucket = s3_resource.Bucket(bucket)
     delete = {
         "Objects": []
     }
     for key in l_object_key:
-        delete["Objects"].append({"Key": key_prefix + key})
+        _, _, key = get_s3_formatted_bucket_path(bucket, "", key)
+        delete["Objects"].append({"Key": key})
     return s3_bucket.delete_objects(Delete=delete)
 
 

--- a/get_data/src/upload_to_db.py
+++ b/get_data/src/upload_to_db.py
@@ -7,7 +7,7 @@ from get_data.src import es_utils
 from get_data.src import utils_fct
 
 
-def remove_missing_pic_from_dic(label_dict):
+def _remove_missing_pic_from_dic(label_dict):
     """
     Check if all pictures referenced in the label_dict exists. All non existing picture are removed from label_dict
     (modification in-place).
@@ -33,17 +33,18 @@ def remove_missing_pic_from_dic(label_dict):
     return missing_pic_id
 
 
-def print_upload_synthesis(bucket, index_name, es_success, failed_es, s3_success, missing_pic, already_exist_pic):
+def _print_upload_synthesis(bucket, index_name, es_success, failed_es, s3_success, missing_pic, already_exist_pic):
     print('----------------------------------------')
     print(f'Upload Completed ! {s3_success} picture(s) uploaded to s3 and {es_success} uploaded to ES')
-    print(f'Upload to s3:')
-    print(f' Upload bucket: "{bucket}"')
-    print(f' {s3_success} picture(s) were successful uploaded to s3.')
-    print(f' {len(missing_pic) + len(already_exist_pic)} upload failed to s3.')
-    if len(missing_pic) > 0:
-        print(f'   --> Picture not found:                   {missing_pic}')
-    if len(already_exist_pic) > 0:
-        print(f'   --> Picture id already exists in bucket: {already_exist_pic}')
+    if bucket is not None:
+        print(f'Upload to s3:')
+        print(f' Upload bucket: "{bucket}"')
+        print(f' {s3_success} picture(s) were successful uploaded to s3.')
+        print(f' {len(missing_pic) + len(already_exist_pic)} upload failed to s3.')
+        if len(missing_pic) > 0:
+            print(f'   --> Picture not found:                   {missing_pic}')
+        if len(already_exist_pic) > 0:
+            print(f'   --> Picture id already exists in bucket: {already_exist_pic}')
     print(f'Upload ES:')
     print(f' Index name: "{index_name}"')
     print(f' {es_success} picture(s) were successful uploaded to ES.')
@@ -70,7 +71,7 @@ def generate_key_prefix(d_label):
     """
     Generate the key key_prefix for a list of label.
     Return None if one of the following test fail:
-        Check that the "event" name is well formated for s3 bucket key.
+        Check that the "event" name is well formatted for s3 bucket key.
         Check all label in the list have the same "event" name
     Return the key_prefix if tests are OK. Key key_prefix is defined as follow:
         "{event_name}/{picture_date}/"
@@ -84,15 +85,15 @@ def generate_key_prefix(d_label):
     for key, label in d_label.items():
         is_valid, regex = s3_utils.is_valid_s3_key(label["event"])
         if not is_valid:
-            print(f'Event name "{label["event"]} contains invalid characters. Char is invalid if it match with:{regex}')
+            print(f'Event name "{label["event"]}" contains invalid character. Char is invalid if it match with:{regex}')
             return None
         if label["event"] != event:
-            print(f'Key bucket can\'t be generated because event name is not unique. Got {event} and {label["event"]}.')
+            print(f'Key bucket can\'t be generated because event name is not unique: "{event}" != "{label["event"]}"')
             return None
     return f'{event}/{date.strftime("%Y%m%d")}/'
 
 
-def upload_to_db(label_file, bucket_name, es_host_ip, es_port, es_index, key_prefix=None, overwrite=False):
+def upload_to_db(label_file, es_host_ip, es_port, es_index, bucket_name=None, key_prefix=None, overwrite=False):
     """
     Upload picture(s) to the DataBase according to the label file.
     Labels are uploaded to Elasticsearch cluster ; pictures are uploaded to S3 bucket.
@@ -110,10 +111,10 @@ def upload_to_db(label_file, bucket_name, es_host_ip, es_port, es_index, key_pre
     then you can add any field you wish to labelized the picture.
     Note: if the picture already exists in s3 and is not overwritten, upload to ES will be tried anyway.
     :param label_file:      [string]    path to the file containing the labels in json format
-    :param bucket_name:     [string]    Name of the s3 bucket
     :param es_host_ip:      [string]    Public ip of the Elasticsearch host server
     :param es_port:         [int]       Port open for Elasticsearch on host server (typically 9200)
     :param es_index:        [string]    Name of the index to use
+    :param bucket_name:     [string]    Name of the s3 bucket. If None, picture won't be uploaded to S3.
     :param overwrite:       [bool]      If True, new picture will overwrite existing ones in S3 with same img_id and new
                                         label will overwrite existing one in ES with same label_fingerprint
                                         If False (default), only non existing picture and label will be uploaded
@@ -124,26 +125,32 @@ def upload_to_db(label_file, bucket_name, es_host_ip, es_port, es_index, key_pre
     :return:                [tuple]     (int) s3 success upload, (int) ES success upload, (int) total nb of failed upload
     """
     d_label = utils_fct.get_label_dict_from_file(label_file)
-    total_label = len(label_file)
+    utils_fct.remove_label_to_delete_from_dict(d_label)
+    print(f'Label file "{label_file}" loaded. {len(d_label)} picture(s) and/or label(s) to upload.')
     if d_label is None:
-        return 0, 0, total_label
-    print(f'Looking for pictures...')
-    missing_pic = remove_missing_pic_from_dic(d_label)
-    if len(d_label) == 0:
-        return 0, 0, total_label
-    if key_prefix is None:
-        key_prefix = generate_key_prefix(d_label)
-        if key_prefix is None:
+        return 0, 0, 0
+    total_label = len(d_label)
+    if bucket_name is not None:
+        print(f'Looking for pictures...')
+        missing_pic = _remove_missing_pic_from_dic(d_label)
+        if len(d_label) == 0:
             return 0, 0, total_label
-    upload_bucket_dir, bucket_name, key_prefix = s3_utils.get_s3_formatted_bucket_path(bucket_name, key_prefix)
-    print(f'Uploading to s3...')
-    s3_upload_success, already_exist_pic = s3_utils.upload_to_s3_from_label(d_label, bucket_name, key_prefix, overwrite)
-    utils_fct.edit_label(d_label, "location", upload_bucket_dir)
-    utils_fct.edit_label(d_label, "upload_date", datetime.now().strftime("%Y%m%dT%H-%M-%S-%f"))
+        if key_prefix is None:
+            key_prefix = generate_key_prefix(d_label)
+            if key_prefix is None:
+                return 0, 0, total_label
+        upload_bucket_dir, bucket_name, key_prefix = s3_utils.get_s3_formatted_bucket_path(bucket_name, key_prefix)
+        print(f'Uploading to s3...')
+        s3_upload_success, already_exist_pic = s3_utils.upload_to_s3_from_label(d_label, bucket_name, key_prefix, overwrite)
+        utils_fct.edit_label(d_label, "location", upload_bucket_dir)
+        utils_fct.edit_label(d_label, "upload_date", datetime.now().strftime("%Y%m%dT%H-%M-%S-%f"))
+    else:
+        upload_bucket_dir = None
+        s3_upload_success = missing_pic = already_exist_pic = []
     print(f'Uploading to Elasticsearch cluster...')
     failed_es_upload = es_utils.upload_to_es(
         d_label=d_label, index=es_index, host_ip=es_host_ip, port=es_port, overwrite=overwrite)
     es_success = len(d_label) - len(failed_es_upload)
-    print_upload_synthesis(upload_bucket_dir, es_index,
-                           es_success, failed_es_upload, len(s3_upload_success), missing_pic, already_exist_pic)
+    _print_upload_synthesis(upload_bucket_dir, es_index,
+                            es_success, failed_es_upload, len(s3_upload_success), missing_pic, already_exist_pic)
     return len(s3_upload_success), es_success, len(failed_es_upload) + len(already_exist_pic) + len(missing_pic)

--- a/get_data/src/utils_fct.py
+++ b/get_data/src/utils_fct.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import json
 import hashlib
 
+from get_data.src import s3_utils
+
 
 def get_label_file_name(label_file):
     """Generate a unique label file name based on now timestamp."""
@@ -17,6 +19,35 @@ def get_label_dict_from_file(file):
     with Path(file).open(mode='r', encoding='utf-8') as fp:
         d_label = json.load(fp)
     return d_label
+
+
+def remove_label_to_delete_from_dict(d_label):
+    """
+    Removed label in a dictionary of labels that have a "to_delete" field set to True. Label are removed from the
+    dictionary in place.
+    :param d_label:     [dict]          Dictionary of labels where the key is the img_id the label points to and the
+                                        value is the label itself:
+                                        {
+                                          "20200115T15-45-55-123456": {...},
+                                          ...
+                                        }
+    :return:            [list of dict]  List of item removed from the input dictionary:
+                                        [{"img_id": "xxx", "s3_key": "xxx", "label_fingerprint": "xxx"}, {...}, ...]
+    """
+    l_removed_item = []
+    for img_id in list(d_label.keys()):
+        label = d_label[img_id]
+        try:
+            to_delete = label["to_delete"]
+            if not to_delete:
+                label.pop("to_delete")
+        except KeyError:
+            to_delete = False
+        if to_delete:
+            d_label.pop(img_id)
+            _, _, s3_key = s3_utils.get_s3_formatted_bucket_path(label["location"], "", label["img_id"])
+            l_removed_item.append({"img_id": img_id, "s3_key": s3_key, "label_fingerprint": label["label_fingerprint"]})
+    return l_removed_item
 
 
 def edit_label(d_label, field, value):

--- a/get_data/upload_data.py
+++ b/get_data/upload_data.py
@@ -6,6 +6,7 @@ PARENT_DIR = os.path.dirname(CURRENT_DIR)
 sys.path.append(PARENT_DIR)
 
 from get_data.src import upload_to_db as upload
+from get_data.src import update_db
 from conf import cluster_conf
 
 
@@ -22,13 +23,16 @@ def _get_args(description):
     parser.add_argument("-f", "--force", action="store_true",
                         help="Force option will overwrite existing pictures and labels in S3 and ES with new one"
                              " if same img_id is found")
+    parser.add_argument("-e", "--es_only", default=None,
+                        help="Only upload labels to Elasticsearch cluster and doesn't upload pictures to S3."
+                             "However, picture in S3 will still be removed based on instruction from the label_file.")
     return parser.parse_args()
 
 
 def upload_data():
     """
-    Upload date picture and label to S3 and ES from a label file (json format). The label file can contain one or
-    a list of label.
+    Upload and/or Delete picture in S3 and/or label in ES from a label file (json format).
+    The label file can contain one or more label in the form of a dictionary with the img_id as key for each label.
     To see a label template, use the write_label_template.py function.
     You will need credential for the upload. Access keys shall be defined in the following environment variables:
     export PATATE_S3_KEY_ID="your_access_key_id"
@@ -43,8 +47,9 @@ def upload_data():
     es_index_name = cluster_conf.ES_INDEX if args.index is None else args.index
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                        overwrite=args.force, key_prefix=key_prefix)
+    update_db.delete_picture_and_label(label_file, es_index=es_index_name, bucket=bucket_name)
+    upload.upload_to_db(label_file, es_ip_host, es_port_host, es_index_name,
+                        bucket_name=bucket_name, overwrite=args.force, key_prefix=key_prefix)
 
 
 if __name__ == "__main__":

--- a/test/resources/labels_block_delete.json
+++ b/test/resources/labels_block_delete.json
@@ -1,0 +1,85 @@
+{
+    "20200204T15-23-08-574348": {
+        "location": "test/resources",
+        "car_setting": {
+            "camera": {
+                "resolution-horizontal": 160,
+                "resolution-vertical": 96,
+                "frame_rate": 32,
+                "exposure_mode": "off",
+                "camera_position": 120
+            },
+            "constant": {
+                "max_speed": 307,
+                "stop_speed": 322,
+                "max_direction_l": 1,
+                "max_direction_r": 651,
+                "joystick_to_raw_dir_mapping": [],
+                "trigger_to_raw_speed_mapping": [],
+                "label_to_raw_dir_mapping": [
+                    250,
+                    290,
+                    327,
+                    364,
+                    400
+                ],
+                "label_to_raw_speed_mapping": [
+                    316,
+                    311
+                ],
+                "head_up": 150,
+                "head_down": 120
+            }
+        },
+        "hardware_conf": {
+            "car": "patate",
+            "version": 1,
+            "computer": "Raspberry_Pi2",
+            "camera": "Picam"
+        },
+        "event": "unittest",
+        "track": "",
+        "track_picture": "",
+        "track_type": "single lane",
+        "dataset": [
+            {
+                "name": "",
+                "comment": "",
+                "query": null
+            }
+        ],
+        "comment": "this is the demo",
+        "raw_picture": true,
+        "upload_date": "20200205T12-40-42-306536",
+        "img_id": "20200204T15-23-08-574348",
+        "file_name": "20200204T15-23-08-574348.jpg",
+        "file_type": "jpg",
+        "raw_value": {
+            "raw_direction": 326,
+            "raw_speed": 307,
+            "normalized_speed": 1.0,
+            "normalized_direction": 0.0
+        },
+        "label": {
+            "label_direction": 2,
+            "label_speed": 1,
+            "created_by": "auto",
+            "created_on_date": "20200204T15-23-08-574932",
+            "raw_dir_to_label_mapping": [
+                250,
+                290,
+                327,
+                364,
+                400
+            ],
+            "raw_speed_to_label_mapping": [
+                316,
+                311
+            ],
+            "nb_of_direction": 5,
+            "nb_of_speed": 2
+        },
+        "timestamp": "20200204T15-23-08-574348",
+        "label_fingerprint": "50b65c5a54c4fc04ba9859307755ddf8"
+    }
+}

--- a/test/resources/labels_delete.json
+++ b/test/resources/labels_delete.json
@@ -1,5 +1,6 @@
 {
     "20200204T15-23-08-574348": {
+        "to_delete": true,
         "location": "test/resources",
         "car_setting": {
             "camera": {
@@ -83,6 +84,7 @@
         "label_fingerprint": "ff4c8a7882ae8d4d9a2d139ff420a62b"
     },
     "20200204T15-23-08-695024": {
+        "to_delete": true,
         "location": "test/resources",
         "car_setting": {
             "camera": {

--- a/test/test_functional_download.py
+++ b/test/test_functional_download.py
@@ -17,6 +17,8 @@ def test_init():
     es_index_name = "test_index"
     output_test_folder = Path("output_test_folder")
     output_test_folder.mkdir(exist_ok=True)
+    es_utils.delete_index(es_index_name, host_ip=cluster_conf.ES_HOST_IP, port=cluster_conf.ES_HOST_PORT)
+    es_utils.create_es_index(cluster_conf.ES_HOST_IP, cluster_conf.ES_HOST_PORT, es_index_name)
     yield output_test_folder, bucket_name, key_prefix, es_ip_host, es_port_host, es_index_name
     print("--------------- Test completed ----------------")
     print("Deleting test pictures from s3")
@@ -36,8 +38,8 @@ def test_download_single_file(test_init):
         label = json.load(fp)
     first_key = next(iter(label))
     output = Path(output_test_folder) / label[first_key]["file_name"]
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, es_index_name,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
     if fail > 0:
         raise RuntimeError("Failed to upload to s3, can't test download if upload is not working")
     time.sleep(1)
@@ -48,14 +50,14 @@ def test_download_single_file(test_init):
 def test_download_full_pipeline(test_init):
     label_file = "test/resources/labels.json"
     output_test_folder, bucket_name, key_prefix, es_ip_host, es_port_host, es_index_name = test_init
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, es_index_name,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
     assert fail == 1
     search = {
         "event": {
             "type": "match",
             "field": "",
-            "query": "demo_session"
+            "query": "unittest"
         }
     }
     search_json = "tmp_search_test.json"

--- a/test/test_functional_update_db.py
+++ b/test/test_functional_update_db.py
@@ -1,0 +1,61 @@
+import pytest
+
+
+from get_data.src import update_db
+from get_data.src import upload_to_db
+from get_data.src import es_utils
+from conf.cluster_conf import ES_HOST_PORT, ES_HOST_IP, BUCKET_NAME
+
+
+ES_TEST_INDEX = "test_index"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def create_test_index():
+    es_utils.delete_index(ES_TEST_INDEX, host_ip=ES_HOST_IP, port=ES_HOST_PORT)
+    es_utils.create_es_index(ES_HOST_IP, ES_HOST_PORT, ES_TEST_INDEX)
+
+
+def test_delete_pic_and_label():
+    file = "test/resources/labels.json"
+    file_delete = "test/resources/labels_delete.json"
+    key_prefix = "resources"
+    upload_to_db.upload_to_db(file, es_index=ES_TEST_INDEX, es_host_ip=ES_HOST_IP, es_port=ES_HOST_PORT,
+                              bucket_name=BUCKET_NAME, key_prefix=key_prefix)
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(file_delete, es_index=ES_TEST_INDEX, bucket=BUCKET_NAME, force=True)
+    assert (2, 0, 2, 0) == (success_es, fail_es, success_s3, fail_s3)
+    update_db.delete_pic_and_index(file, BUCKET_NAME, key_prefix, ES_TEST_INDEX, ES_HOST_IP, ES_HOST_PORT)
+
+
+def test_delete_pic_and_label_wrong_key_prefix():
+    file = "test/resources/labels.json"
+    file_delete = "test/resources/labels_delete.json"
+    key_prefix = "wrong_key_prefix"
+    upload_to_db.upload_to_db(file, es_index=ES_TEST_INDEX, es_host_ip=ES_HOST_IP, es_port=ES_HOST_PORT,
+                              bucket_name=BUCKET_NAME, key_prefix=key_prefix)
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(file_delete, es_index=ES_TEST_INDEX, bucket=BUCKET_NAME, force=True)
+    assert (2, 0, 0, 2) == (success_es, fail_es, success_s3, fail_s3)
+    update_db.delete_pic_and_index(file, BUCKET_NAME, key_prefix, ES_TEST_INDEX, ES_HOST_IP, ES_HOST_PORT)
+
+
+def test_delete_pic_and_label_other_label_points_to_pic():
+    file = "test/resources/labels.json"
+    file_delete = "test/resources/labels_delete.json"
+    file_blocking_label = "test/resources/labels_block_delete.json"
+    key_prefix = "resources"
+    upload_to_db.upload_to_db(file, es_index=ES_TEST_INDEX, es_host_ip=ES_HOST_IP, es_port=ES_HOST_PORT,
+                              bucket_name=BUCKET_NAME, key_prefix=key_prefix)
+    upload_to_db.upload_to_db(file_blocking_label, es_index=ES_TEST_INDEX, es_host_ip=ES_HOST_IP, es_port=ES_HOST_PORT)
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(file_delete, es_index=ES_TEST_INDEX, bucket=BUCKET_NAME, force=True)
+    assert (2, 0, 1, 1) == (success_es, fail_es, success_s3, fail_s3)
+    update_db.delete_pic_and_index(file, BUCKET_NAME, key_prefix, ES_TEST_INDEX, ES_HOST_IP, ES_HOST_PORT)
+
+
+def test_delete_pic_and_label_nothing_to_delete():
+    file = "test/resources/labels.json"
+    key_prefix = "wrong_key_prefix"
+    upload_to_db.upload_to_db(file, es_index=ES_TEST_INDEX, es_host_ip=ES_HOST_IP, es_port=ES_HOST_PORT,
+                              bucket_name=BUCKET_NAME, key_prefix=key_prefix)
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(file, es_index=ES_TEST_INDEX, bucket=BUCKET_NAME, force=True)
+    assert (0, 0, 0, 0) == (success_es, fail_es, success_s3, fail_s3)
+    update_db.delete_pic_and_index(file, BUCKET_NAME, key_prefix, ES_TEST_INDEX, ES_HOST_IP, ES_HOST_PORT)

--- a/test/test_functional_upload_to_db.py
+++ b/test/test_functional_upload_to_db.py
@@ -1,33 +1,19 @@
-import time
+import pytest
 
 from conf import cluster_conf
 from get_data.src import upload_to_db as upload
 from get_data.src import update_db
-from get_data.src import s3_utils
 from get_data.src import es_utils
-from get_data.src import utils_fct
 from conf.cluster_conf import ES_HOST_PORT, ES_HOST_IP
 
 
-def delete_pic_and_index(label_file, bucket_name, key_prefix, index, es_ip, es_port, s3_only=False):
-    d_label = utils_fct.get_label_dict_from_file(label_file)
-    l_picture_id = list(d_label.keys())
-    s3_utils.delete_object_s3(bucket_name, key_prefix, l_picture_id)
-    if not s3_only:
-        es_utils.delete_index(index, es_ip, es_port)
+ES_TEST_INDEX = "test_index"
 
 
-def test_upload_to_db():
-    label_file = "test/resources/labels.json"
-    bucket_name = cluster_conf.BUCKET_NAME
-    key_prefix = ""
-    es_ip_host = cluster_conf.ES_HOST_IP
-    es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=False)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
-    assert (s3_success, es_success, fail) == (3, 3, 1)
+@pytest.fixture(scope="function", autouse=True)
+def create_test_index():
+    es_utils.delete_index(ES_TEST_INDEX, host_ip=cluster_conf.ES_HOST_IP, port=cluster_conf.ES_HOST_PORT)
+    es_utils.create_es_index(ES_HOST_IP, ES_HOST_PORT, ES_TEST_INDEX)
 
 
 def test_upload_to_db_overwrite():
@@ -36,12 +22,23 @@ def test_upload_to_db_overwrite():
     key_prefix = ""
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
+    assert (s3_success, es_success, fail) == (3, 3, 1)
+
+
+def test_upload_to_db():
+    label_file = "test/resources/labels.json"
+    bucket_name = cluster_conf.BUCKET_NAME
+    key_prefix = ""
+    es_ip_host = cluster_conf.ES_HOST_IP
+    es_port_host = cluster_conf.ES_HOST_PORT
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (3, 3, 1)
 
 
@@ -51,13 +48,12 @@ def test_upload_to_db_s3_KO_es_OK():
     key_prefix = ""
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    es_utils.delete_index(es_index_name, es_ip_host, es_port_host)
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=False)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    es_utils.delete_index(ES_TEST_INDEX, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (0, 3, 4)
 
 
@@ -67,13 +63,12 @@ def test_upload_to_db_s3_OK_es_KO():
     key_prefix = ""
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host, s3_only=True)
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=False)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host, s3_only=True)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (3, 0, 4)
 
 
@@ -83,12 +78,11 @@ def test_upload_to_db_cant_overwrite():
     key_prefix = ""
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=False)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=False)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (0, 0, 7)
 
 
@@ -98,10 +92,9 @@ def test_upload_to_db_key_prefix():
     key_prefix = "/weird/path//"
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=False)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (3, 3, 1)
 
 
@@ -111,16 +104,31 @@ def test_upload_to_db_single_label():
     key_prefix = ""
     es_ip_host = cluster_conf.ES_HOST_IP
     es_port_host = cluster_conf.ES_HOST_PORT
-    es_index_name = "test_index"
-    s3_success, es_success, fail = upload.upload_to_db(label_file, bucket_name, es_ip_host, es_port_host, es_index_name,
-                                                       key_prefix=key_prefix, overwrite=True)
-    delete_pic_and_index(label_file, bucket_name, key_prefix, es_index_name, es_ip_host, es_port_host)
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
     assert (s3_success, es_success, fail) == (1, 1, 0)
 
 
-def test_create_index():
-    index = "test_create_index"
-    create_success = es_utils.create_es_index(host_ip=ES_HOST_IP, host_port=ES_HOST_PORT, index_name=index)
-    assert create_success is not None
-    del_success = es_utils.delete_index(index=index, host_ip=ES_HOST_IP, port=ES_HOST_PORT)
-    assert del_success is not None
+def test_upload_to_db_es_only():
+    label_file = "test/resources/labels.json"
+    bucket_name = cluster_conf.BUCKET_NAME
+    key_prefix = ""
+    es_ip_host = cluster_conf.ES_HOST_IP
+    es_port_host = cluster_conf.ES_HOST_PORT
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=None, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
+    assert (s3_success, es_success, fail) == (0, 4, 0)
+
+
+def test_upload_to_db_remove_todelete_label():
+    label_file = "test/resources/labels_delete.json"
+    bucket_name = cluster_conf.BUCKET_NAME
+    key_prefix = ""
+    es_ip_host = cluster_conf.ES_HOST_IP
+    es_port_host = cluster_conf.ES_HOST_PORT
+    s3_success, es_success, fail = upload.upload_to_db(label_file, es_ip_host, es_port_host, ES_TEST_INDEX,
+                                                       bucket_name=bucket_name, key_prefix=key_prefix, overwrite=True)
+    update_db.delete_pic_and_index(label_file, bucket_name, key_prefix, ES_TEST_INDEX, es_ip_host, es_port_host)
+    assert (s3_success, es_success, fail) == (1, 1, 1)

--- a/test/test_get_data_utils.py
+++ b/test/test_get_data_utils.py
@@ -1,0 +1,68 @@
+
+from get_data.src import utils_fct
+
+
+def test_remove_label_to_delete():
+    d_label = utils_fct.get_label_dict_from_file("test/resources/labels_delete.json")
+    l_to_delete = utils_fct.remove_label_to_delete_from_dict(d_label)
+    for _, label in d_label.items():
+        assert "to_delete" not in label
+    assert len(l_to_delete) == 2
+    assert len(d_label) == 2
+
+
+def test_remove_label_to_delete_nothing2delete():
+    d_label = utils_fct.get_label_dict_from_file("test/resources/labels.json")
+    l_to_delete = utils_fct.remove_label_to_delete_from_dict(d_label)
+    for _, label in d_label.items():
+        assert "to_delete" not in label
+    assert len(l_to_delete) == 0
+    assert len(d_label) == 4
+
+
+def test_remove_label_to_delete_todelete_false():
+    d_label = {
+        "20200212T15-39-30-123456": {
+            "to_delete": False,
+            "img_id": "20200212T15-39-30-123456",
+            "location": "my-bucket",
+            "label_fingerprint": "e170fca7848a59a815d2288802cc2832"
+        },
+        "20200212T15-39-30-987654": {
+            "to_delete": True,
+            "img_id": "20200212T15-39-30-987654",
+            "location": "my-bucket",
+            "label_fingerprint": "e170fca7848a59a815d2288802aa1111"
+        }
+    }
+    l_to_delete = utils_fct.remove_label_to_delete_from_dict(d_label)
+    for _, label in d_label.items():
+        assert "to_delete" not in label
+    assert len(l_to_delete) == 1
+    assert len(d_label) == 1
+
+
+def test_get_label_fingerprint_all_different():
+    d_label = utils_fct.get_label_dict_from_file("test/resources/labels.json")
+    for img_id, label in d_label.items():
+        fingerprint = utils_fct.get_label_finger_print(label)
+        for img_id_bis, label_bis in d_label.items():
+            if img_id == img_id_bis: continue
+            assert fingerprint != utils_fct.get_label_finger_print(label_bis)
+
+
+def test_get_label_fingerprint_invariant():
+    d_label = utils_fct.get_label_dict_from_file("test/resources/labels.json")
+    d_fingerprint = {}
+    for img_id, label in d_label.items():
+        d_fingerprint[img_id] = utils_fct.get_label_finger_print(label)
+    for img_id, label in d_label.items():
+        assert d_fingerprint[img_id] == utils_fct.get_label_finger_print(label)
+
+
+def test_get_label_fingerprint_depends_on_imgid():
+    d_label = utils_fct.get_label_dict_from_file("test/resources/labels.json")
+    img_id, label = next(iter(d_label.items()))
+    fingerprint = utils_fct.get_label_finger_print(label)
+    label["img_id"] = img_id[1:]
+    assert fingerprint != utils_fct.get_label_finger_print(label)

--- a/test/test_s3_utils.py
+++ b/test/test_s3_utils.py
@@ -101,6 +101,16 @@ def test_get_s3_formatted_bucket_path_double_nokey_with_filename():
     assert res == ("my-bucket/key_prefix/file.jpg", "my-bucket", "key_prefix/file.jpg")
 
 
+def test_get_s3_formatted_bucket_key_prefix_in_bucket():
+    res = s3_utils.get_s3_formatted_bucket_path("my-bucket/key/prefix", "")
+    assert res == ("my-bucket/key/prefix/", "my-bucket", "key/prefix/")
+
+
+def test_get_s3_formatted_bucket_key_prefix_in_bucket_plus_file():
+    res = s3_utils.get_s3_formatted_bucket_path("my-bucket/key/prefix", "", "/file")
+    assert res == ("my-bucket/key/prefix/file", "my-bucket", "key/prefix/file")
+
+
 def test_generate_key_prefix_ok():
     date_str = datetime.now().strftime("%Y%m%dT%H-%M-%S-%f")
     date = datetime.now()

--- a/utils/modify_label_json_file.py
+++ b/utils/modify_label_json_file.py
@@ -55,11 +55,12 @@ def custom_change_field(json_file):
     with Path(json_file).open(mode='r', encoding='utf-8') as fp:
         d_label = json.load(fp)
     for img_id, label in d_label.items():
-        label["file_name"] = Path(label["file_name"]).stem.split("#")[0] + Path(label["file_name"]).suffix
+        label["label_fingerprint"] = utils_fct.get_label_finger_print(label)
     with Path(json_file).open(mode='w', encoding='utf-8') as fp:
         json.dump(d_label, fp, indent=4)
 
 
 if __name__ == "__main__":
     # substitute_matching_char()
-    custom_change_field("../test/resources/labels.json")
+    custom_change_field("../test/resources/labels_block_delete.json")
+    pass


### PR DESCRIPTION
New feature:  
- function delete_picture_and_label to safely delete labels and pictures based on a json file: All labels with a field "to_delete" will be deleted from ES and the associated pic will be deleted from S3 but only if no other labels in the database points to it.  
- Readme update to explain (partly) hot to manually re labelize pictures.  

Test case done :  
- upload 4 labels + pics, then delete 2: OK
- upload 4 labels + pics, then try to delete but can't find picture (wrong key): 2 labels deleted but no pics deleted and exit properly
- try to delete pic but label in ES still point to it: no pic delete and exit properly
- upload with a label file with no "to_delete" field: nothing is deleted

