### PR TITLE
fix: delete at upload if no s3 bucket fixed + functional test added

### DIFF
--- a/get_data/src/update_db.py
+++ b/get_data/src/update_db.py
@@ -117,7 +117,7 @@ def delete_picture_and_label(label_file, es_index=ES_INDEX, bucket=BUCKET_NAME, 
     if not force and not _user_ok_for_deletion(label_file, len(l_img_to_delete), delete_local, label_only=not bool(bucket)):
         return 0, 0, 0, 0
     es = es_utils.get_es_session(host_ip=ES_HOST_IP, port=ES_HOST_PORT)
-    print(f'Deleting {len(l_img_to_delete)} label(s) in index "{es_index}" ({ES_HOST_IP}:{ES_HOST_PORT})...')
+    print(f'Deleting {len(l_label_fingerprint_to_delete)} labels in index "{es_index}" {ES_HOST_IP}:{ES_HOST_PORT}...')
     i_es_success, l_failed_es = es_utils.delete_document(es=es, index=es_index, l_doc_id=l_label_fingerprint_to_delete)
     print(f'{i_es_success} label(s) successfully deleted from index "{es_index}" ({ES_HOST_IP}:{ES_HOST_PORT})')
     time.sleep(1)
@@ -129,6 +129,8 @@ def delete_picture_and_label(label_file, es_index=ES_INDEX, bucket=BUCKET_NAME, 
         s3 = s3_utils.get_s3_resource()
         print(f'Deleting {len(l_img_to_delete)} picture(s) in s3...')
         for img_id, s3_key in l_img_to_delete:
+            if s3_key is None or s3_key == "":
+                continue
             s = s.query("match", img_id=img_id)
             response = s.execute()
             if response.hits.total.value > 0:

--- a/get_data/src/update_db.py
+++ b/get_data/src/update_db.py
@@ -155,7 +155,7 @@ def delete_picture_and_label(label_file, es_index=ES_INDEX, bucket=BUCKET_NAME, 
     print(f'ES: {i_es_success} deletion(s) ; {len(l_failed_es)} failed.')
     print(f'S3: {len(l_ok_delete)} deletion(s) ; {len(l_failed_s3)} failed')
     print(f'{nb_local_pic_deleted} picture(s) deleted from local drive.')
-    return i_es_success, len(l_failed_es), len(l_img_to_delete) - len(l_failed_s3), len(l_failed_s3)
+    return i_es_success, len(l_failed_es), len(l_ok_delete), len(l_failed_s3)
 
 
 def delete_pic_and_index(label_file, bucket_name, key_prefix, index, es_ip, es_port, s3_only=False):

--- a/test/resources/labels_delete_no_bucket.json
+++ b/test/resources/labels_delete_no_bucket.json
@@ -1,0 +1,338 @@
+{
+    "20200204T15-23-08-574348": {
+        "to_delete": true,
+        "s3_bucket": "",
+        "car_setting": {
+            "camera": {
+                "resolution-horizontal": 160,
+                "resolution-vertical": 96,
+                "frame_rate": 32,
+                "exposure_mode": "off",
+                "camera_position": 120
+            },
+            "constant": {
+                "max_speed": 307,
+                "stop_speed": 322,
+                "max_direction_l": 1,
+                "max_direction_r": 651,
+                "joystick_to_raw_dir_mapping": [],
+                "trigger_to_raw_speed_mapping": [],
+                "label_to_raw_dir_mapping": [
+                    250,
+                    290,
+                    327,
+                    364,
+                    400
+                ],
+                "label_to_raw_speed_mapping": [
+                    316,
+                    311
+                ],
+                "head_up": 150,
+                "head_down": 120
+            }
+        },
+        "hardware_conf": {
+            "car": "patate",
+            "version": 1,
+            "computer": "Raspberry_Pi2",
+            "camera": "Picam"
+        },
+        "event": "unittest",
+        "track": "",
+        "track_picture": "",
+        "track_type": "single lane",
+        "dataset": [
+            {
+                "name": "",
+                "comment": "",
+                "query": null
+            }
+        ],
+        "comment": "this is the demo",
+        "raw_picture": true,
+        "upload_date": "",
+        "img_id": "20200204T15-23-08-574348",
+        "file_name": "20200204T15-23-08-574348.jpg",
+        "file_type": "jpg",
+        "raw_value": {
+            "raw_direction": 326,
+            "raw_speed": 307,
+            "normalized_speed": 1.0,
+            "normalized_direction": 0.0
+        },
+        "label": {
+            "label_direction": 2,
+            "label_speed": 0,
+            "created_by": "auto",
+            "created_on_date": "20200204T15-23-08-574932",
+            "raw_dir_to_label_mapping": [
+                250,
+                290,
+                327,
+                364,
+                400
+            ],
+            "raw_speed_to_label_mapping": [
+                316,
+                311
+            ],
+            "nb_of_direction": 5,
+            "nb_of_speed": 2
+        },
+        "timestamp": "20200204T15-23-08-574348",
+        "label_fingerprint": "ff4c8a7882ae8d4d9a2d139ff420a62b"
+    },
+    "20200204T15-23-08-695024": {
+        "to_delete": true,
+        "s3_bucket": "",
+        "car_setting": {
+            "camera": {
+                "resolution-horizontal": 160,
+                "resolution-vertical": 96,
+                "frame_rate": 32,
+                "exposure_mode": "off",
+                "camera_position": 120
+            },
+            "constant": {
+                "max_speed": 307,
+                "stop_speed": 322,
+                "max_direction_l": 1,
+                "max_direction_r": 651,
+                "joystick_to_raw_dir_mapping": [],
+                "trigger_to_raw_speed_mapping": [],
+                "label_to_raw_dir_mapping": [
+                    250,
+                    290,
+                    327,
+                    364,
+                    400
+                ],
+                "label_to_raw_speed_mapping": [
+                    316,
+                    311
+                ],
+                "head_up": 150,
+                "head_down": 120
+            }
+        },
+        "hardware_conf": {
+            "car": "patate",
+            "version": 1,
+            "computer": "Raspberry_Pi2",
+            "camera": "Picam"
+        },
+        "event": "unittest",
+        "track": "",
+        "track_picture": "",
+        "track_type": "single lane",
+        "dataset": [
+            {
+                "name": "",
+                "comment": "",
+                "query": null
+            }
+        ],
+        "comment": "this is the demo",
+        "raw_picture": true,
+        "upload_date": "",
+        "img_id": "20200204T15-23-08-695024",
+        "file_name": "20200204T15-23-08-695024.jpg",
+        "file_type": "jpg",
+        "raw_value": {
+            "raw_direction": 326,
+            "raw_speed": 307,
+            "normalized_speed": 1.0,
+            "normalized_direction": 0.0
+        },
+        "label": {
+            "label_direction": 2,
+            "label_speed": 0,
+            "created_by": "auto",
+            "created_on_date": "20200204T15-23-08-695607",
+            "raw_dir_to_label_mapping": [
+                250,
+                290,
+                327,
+                364,
+                400
+            ],
+            "raw_speed_to_label_mapping": [
+                316,
+                311
+            ],
+            "nb_of_direction": 5,
+            "nb_of_speed": 2
+        },
+        "timestamp": "20200204T15-23-08-695024",
+        "label_fingerprint": "beae513889776ada9ac0e8ee800f65c1"
+    },
+    "20200204T15-23-19-881268": {
+        "to_delete": true,
+        "s3_bucket": "",
+        "car_setting": {
+            "camera": {
+                "resolution-horizontal": 160,
+                "resolution-vertical": 96,
+                "frame_rate": 32,
+                "exposure_mode": "off",
+                "camera_position": 120
+            },
+            "constant": {
+                "max_speed": 307,
+                "stop_speed": 322,
+                "max_direction_l": 1,
+                "max_direction_r": 651,
+                "joystick_to_raw_dir_mapping": [],
+                "trigger_to_raw_speed_mapping": [],
+                "label_to_raw_dir_mapping": [
+                    250,
+                    290,
+                    327,
+                    364,
+                    400
+                ],
+                "label_to_raw_speed_mapping": [
+                    316,
+                    311
+                ],
+                "head_up": 150,
+                "head_down": 120
+            }
+        },
+        "hardware_conf": {
+            "car": "patate",
+            "version": 1,
+            "computer": "Raspberry_Pi2",
+            "camera": "Picam"
+        },
+        "event": "unittest",
+        "track": "",
+        "track_picture": "",
+        "track_type": "single lane",
+        "dataset": [
+            {
+                "name": "",
+                "comment": "",
+                "query": null
+            }
+        ],
+        "comment": "this is the demo",
+        "raw_picture": true,
+        "upload_date": "",
+        "img_id": "20200204T15-23-19-881268",
+        "file_name": "20200204T15-23-19-881268.jpg",
+        "file_type": "jpg",
+        "raw_value": {
+            "raw_direction": 326,
+            "raw_speed": 317,
+            "normalized_speed": 0.33,
+            "normalized_direction": 0.0
+        },
+        "label": {
+            "label_direction": 2,
+            "label_speed": 2,
+            "created_by": "auto",
+            "created_on_date": "20200204T15-23-19-881825",
+            "raw_dir_to_label_mapping": [
+                250,
+                290,
+                327,
+                364,
+                400
+            ],
+            "raw_speed_to_label_mapping": [
+                316,
+                311
+            ],
+            "nb_of_direction": 5,
+            "nb_of_speed": 2
+        },
+        "timestamp": "20200204T15-23-19-881268",
+        "label_fingerprint": "e170fca7848a59a815d2288802cc2832"
+    },
+    "20200204T15-23-19-111111": {
+        "to_delete": true,
+        "s3_bucket": "",
+        "car_setting": {
+            "camera": {
+                "resolution-horizontal": 160,
+                "resolution-vertical": 96,
+                "frame_rate": 32,
+                "exposure_mode": "off",
+                "camera_position": 120
+            },
+            "constant": {
+                "max_speed": 307,
+                "stop_speed": 322,
+                "max_direction_l": 1,
+                "max_direction_r": 651,
+                "joystick_to_raw_dir_mapping": [],
+                "trigger_to_raw_speed_mapping": [],
+                "label_to_raw_dir_mapping": [
+                    250,
+                    290,
+                    327,
+                    364,
+                    400
+                ],
+                "label_to_raw_speed_mapping": [
+                    316,
+                    311
+                ],
+                "head_up": 150,
+                "head_down": 120
+            }
+        },
+        "hardware_conf": {
+            "car": "patate",
+            "version": 1,
+            "computer": "Raspberry_Pi2",
+            "camera": "Picam"
+        },
+        "event": "unittest",
+        "track": "",
+        "track_picture": "",
+        "track_type": "single lane",
+        "dataset": [
+            {
+                "name": "",
+                "comment": "",
+                "query": null
+            }
+        ],
+        "comment": "this is the demo",
+        "raw_picture": true,
+        "upload_date": "",
+        "img_id": "20200204T15-23-19-111111",
+        "file_name": "20200204T15-23-19-111111.jpg",
+        "file_type": "jpg",
+        "raw_value": {
+            "raw_direction": 326,
+            "raw_speed": 317,
+            "normalized_speed": 0.33,
+            "normalized_direction": 0.0
+        },
+        "label": {
+            "label_direction": 2,
+            "label_speed": 2,
+            "created_by": "auto",
+            "created_on_date": "20200204T15-23-19-881825",
+            "raw_dir_to_label_mapping": [
+                250,
+                290,
+                327,
+                364,
+                400
+            ],
+            "raw_speed_to_label_mapping": [
+                316,
+                311
+            ],
+            "nb_of_direction": 5,
+            "nb_of_speed": 2
+        },
+        "timestamp": "20200204T15-23-19-111111",
+        "label_fingerprint": "e170fca7848a59a815d2288802111111"
+    }
+}

--- a/test/test_functional_update_db.py
+++ b/test/test_functional_update_db.py
@@ -18,6 +18,7 @@ LABELS_DELETE = "test/resources/labels_delete.json"
 LABELS_BLOCK_DELETE = "test/resources/labels_block_delete.json"
 TMP_LABELS = "test/.tmp/labels.json"
 TMP_LABELS_DELETE = "test/.tmp/labels_delete.json"
+TMP_LABELS_DELETE_NO_BUCKET = "test/.tmp/labels_delete_no_bucket.json"
 KEY_PREFIX = "unittest"
 WRONG_KEY_PREFIX = "wrong_key_prefix"
 
@@ -132,6 +133,28 @@ def test_delete_pic_and_label_local_delete_true(create_delete_tmp_folder):
     assert total_file_in_tmp - 2 == len(list(Path("test/.tmp").iterdir()))
     assert not (Path(TMP_LABELS_DELETE).parent / "20200204T15-23-08-574348.jpg").is_file()
     assert not (Path(TMP_LABELS_DELETE).parent / "20200204T15-23-08-695024.jpg").is_file()
+
+
+def test_delete_pic_and_label_not_yet_uploaded_local_delete_false(create_delete_tmp_folder):
+    total_file_in_tmp = len(list(Path("test/.tmp").iterdir()))
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(TMP_LABELS_DELETE_NO_BUCKET,
+                                                                                  es_index=ES_TEST_INDEX,
+                                                                                  bucket=BUCKET_NAME,
+                                                                                  force=True,
+                                                                                  delete_local=False)
+    assert success_s3 == fail_s3 == 0
+    assert total_file_in_tmp == len(list(Path("test/.tmp").iterdir()))
+
+
+def test_delete_pic_and_label_not_yet_uploaded_local_delete_true(create_delete_tmp_folder):
+    total_file_in_tmp = len(list(Path("test/.tmp").iterdir()))
+    success_es, fail_es, success_s3, fail_s3 = update_db.delete_picture_and_label(TMP_LABELS_DELETE_NO_BUCKET,
+                                                                                  es_index=ES_TEST_INDEX,
+                                                                                  bucket=BUCKET_NAME,
+                                                                                  force=True,
+                                                                                  delete_local=True)
+    assert success_s3 == fail_s3 == 0
+    assert total_file_in_tmp - 4 == len(list(Path("test/.tmp").iterdir()))
 
 
 def test_delete_pic_and_label_local_delete_true_pic_not_in_db(create_delete_tmp_folder):

--- a/test/test_functional_update_db.py
+++ b/test/test_functional_update_db.py
@@ -142,7 +142,8 @@ def test_delete_pic_and_label_not_yet_uploaded_local_delete_false(create_delete_
                                                                                   bucket=BUCKET_NAME,
                                                                                   force=True,
                                                                                   delete_local=False)
-    assert success_s3 == fail_s3 == 0
+    assert success_s3 == 0
+    assert fail_s3 == 0
     assert total_file_in_tmp == len(list(Path("test/.tmp").iterdir()))
 
 
@@ -153,8 +154,9 @@ def test_delete_pic_and_label_not_yet_uploaded_local_delete_true(create_delete_t
                                                                                   bucket=BUCKET_NAME,
                                                                                   force=True,
                                                                                   delete_local=True)
-    assert success_s3 == fail_s3 == 0
-    assert total_file_in_tmp - 4 == len(list(Path("test/.tmp").iterdir()))
+    assert success_s3 == 0
+    assert fail_s3 == 0
+    assert total_file_in_tmp - 3 == len(list(Path("test/.tmp").iterdir()))
 
 
 def test_delete_pic_and_label_local_delete_true_pic_not_in_db(create_delete_tmp_folder):


### PR DESCRIPTION
Fix:
- delete picture at upload won't raise an error if no s3_bucket is specifed in the label (ie picture not yet uploaded)